### PR TITLE
Support latexmk aux-directory

### DIFF
--- a/LaTeX.novaextension/CHANGELOG.md
+++ b/LaTeX.novaextension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.2
+
+- ***New:*** Support latexmk `--aux-directory` option to put auxiliary files into custom directory.
+
 ## Version 1.1
 
 - ***Fixed:*** Resolved an (embarrassing) issue with automatic environment closing

--- a/LaTeX.novaextension/Scripts/main.js
+++ b/LaTeX.novaextension/Scripts/main.js
@@ -137,6 +137,12 @@ class LatexTaskProvider {
                         "-c"
                     ];
                 } else return;
+                if (nova.config.get("novalatex.option-auxdir")) {
+                    args = [
+                        ...args,
+                        `--aux-directory=${nova.config.get("novalatex.option-auxdir")}`,
+                    ];
+                }
                 command = "/usr/bin/env";
                 args = [
                     nova.config.get("novalatex.path-latexmk"),

--- a/LaTeX.novaextension/extension.json
+++ b/LaTeX.novaextension/extension.json
@@ -3,7 +3,7 @@
     "name": "LaTeX",
     "organization": "Marco Varisco",
     "description": "Adds support for LaTeX.",
-    "version": "1.1",
+    "version": "1.2",
     "categories": [
         "languages",
         "tasks",
@@ -76,6 +76,14 @@
             "type": "path",
             "default": "latexmk",
             "description": "This needs to be configured only if latexmk is not in $PATH."
+        },
+        {
+            "key": "novalatex.option-auxdir",
+            "title": "Auxiliary Folder Name",
+            "type": "string",
+            "description": "Folder in which to put the auxiliary files (.aux, .log, .fls, …). This uses latexmk’s --aux-directory.",
+            "placeholder": "(Don’t use build folder)",
+            "default": ""
         },
         {
             "key": "novalatex.path-server",


### PR DESCRIPTION
I added an option that puts the auxiliary files into their own subfolder. This is a latexmk feature. It keeps the tex folder cleaner. I tested that the main Nova-LaTeX behavior still work (Like Skim-Synctex).

This is my first time editing/writing a Nova extension, so there might be a rookie mistake in there.